### PR TITLE
Prevent crash on expired job / support named queues

### DIFF
--- a/Tests/TestHangfireIdempotent/DuplicateJobDetectorTests.cs
+++ b/Tests/TestHangfireIdempotent/DuplicateJobDetectorTests.cs
@@ -1,0 +1,95 @@
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Moq;
+
+namespace TestHangfireIdempotent;
+
+[TestFixture]
+public class DuplicateJobDetectorTests
+{
+    [Test]
+    public void IsDuplicateJob_HandlesNullValues_WithoutThrowing()
+    {
+        var monitoringApiMock = new Mock<IMonitoringApi>();
+
+        monitoringApiMock.Setup(m => m.EnqueuedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<EnqueuedJobDto?>([
+                new KeyValuePair<string, EnqueuedJobDto?>("job1", null ),
+                new KeyValuePair<string, EnqueuedJobDto?>("job2", new EnqueuedJobDto { Job = null } ),
+                new KeyValuePair<string, EnqueuedJobDto?>("job3", new EnqueuedJobDto { Job = Job.FromExpression(() => Console.WriteLine("Test")) } )
+            ]));
+            
+        monitoringApiMock.Setup(m => m.ScheduledJobs(It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<ScheduledJobDto?>([
+                new KeyValuePair<string, ScheduledJobDto?>("job1", null),
+                new KeyValuePair<string, ScheduledJobDto?>("job2", new ScheduledJobDto { Job = null }),
+                new KeyValuePair<string, ScheduledJobDto?>("job3", new ScheduledJobDto { Job = Job.FromExpression(() => Console.WriteLine("Test")) } )
+            ]));
+            
+        monitoringApiMock.Setup(m => m.FetchedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<FetchedJobDto?>([
+                new KeyValuePair<string, FetchedJobDto?>("job1", null),
+                new KeyValuePair<string, FetchedJobDto?>("job2", new FetchedJobDto { Job = null }),
+                new KeyValuePair<string, FetchedJobDto?>("job3", new FetchedJobDto { Job = Job.FromExpression(() => Console.WriteLine("Test")) } )
+            ]));
+        
+        var config = new IdempotentConfiguration { MaxRetrievals = 100 };
+        var detector = new DuplicateJobDetector(monitoringApiMock.Object, config);
+        var targetJob = Job.FromExpression(() => Console.WriteLine("Different job"));
+        
+        Assert.DoesNotThrow(() => detector.IsDuplicateJob(targetJob));
+    }
+    
+    [Test]
+    public void IsDuplicateJob_FindsDuplicate_ReturnsTrue()
+    {
+        var targetJob = Job.FromExpression(() => Console.WriteLine("Test"));
+        var duplicateJob = Job.FromExpression(() => Console.WriteLine("Test"));
+        var monitoringApiMock = new Mock<IMonitoringApi>();
+
+        monitoringApiMock.Setup(m => m.EnqueuedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<EnqueuedJobDto?>([
+                new KeyValuePair<string, EnqueuedJobDto?>("job1", new EnqueuedJobDto { Job = duplicateJob })
+            ]));
+            
+        monitoringApiMock.Setup(m => m.ScheduledJobs(It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<ScheduledJobDto>([]));
+            
+        monitoringApiMock.Setup(m => m.FetchedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<FetchedJobDto>([]));
+        
+        var config = new IdempotentConfiguration { MaxRetrievals = 100 };
+        var detector = new DuplicateJobDetector(monitoringApiMock.Object, config);
+        
+        var result = detector.IsDuplicateJob(targetJob);
+        
+        Assert.That(result, Is.True);
+    }
+    
+    [Test]
+    public void IsDuplicateJob_NoDuplicateFound_ReturnsFalse()
+    {
+        var targetJob = Job.FromExpression(() => Console.WriteLine("Test"));
+        var differentJob = Job.FromExpression(() => Console.WriteLine("Different"));
+        var monitoringApiMock = new Mock<IMonitoringApi>();
+
+        monitoringApiMock.Setup(m => m.EnqueuedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<EnqueuedJobDto>([
+                new KeyValuePair<string, EnqueuedJobDto>("job1", new EnqueuedJobDto { Job = differentJob })
+            ]));
+            
+        monitoringApiMock.Setup(m => m.ScheduledJobs(It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<ScheduledJobDto>([]));
+            
+        monitoringApiMock.Setup(m => m.FetchedJobs(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new JobList<FetchedJobDto>([]));
+        
+        var config = new IdempotentConfiguration { MaxRetrievals = 100 };
+        var detector = new DuplicateJobDetector(monitoringApiMock.Object, config);
+        
+        var result = detector.IsDuplicateJob(targetJob);
+        
+        Assert.That(result, Is.False);
+    }
+}

--- a/Tests/TestHangfireIdempotent/TestHangfireIdempotent.csproj
+++ b/Tests/TestHangfireIdempotent/TestHangfireIdempotent.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/Hangfire.Idempotent/DuplicateJobDetector.cs
+++ b/src/Hangfire.Idempotent/DuplicateJobDetector.cs
@@ -27,9 +27,9 @@ public class DuplicateJobDetector
         // Todo: See if we can can insert ourselves into the state change pipeline so we can lock around state changes and avoid race conditions.
         lock (lockObject)
         {
-            enqueued = monitoringApi.EnqueuedJobs(defaultQueue, 0, configuration.MaxRetrievals).ToList();
+            enqueued = monitoringApi.EnqueuedJobs(targetJob.Queue ?? defaultQueue, 0, configuration.MaxRetrievals).ToList();
             scheduled = monitoringApi.ScheduledJobs(0, configuration.MaxRetrievals).ToList();
-            fetched = monitoringApi.FetchedJobs(defaultQueue, 0, configuration.MaxRetrievals).ToList();
+            fetched = monitoringApi.FetchedJobs(targetJob.Queue ?? defaultQueue, 0, configuration.MaxRetrievals).ToList();
         }
 
         foreach (var pair in enqueued)

--- a/src/Hangfire.Idempotent/DuplicateJobDetector.cs
+++ b/src/Hangfire.Idempotent/DuplicateJobDetector.cs
@@ -1,0 +1,68 @@
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+
+namespace Hangfire.Idempotent;
+
+public class DuplicateJobDetector
+{
+    private readonly IMonitoringApi monitoringApi;
+    private readonly object lockObject = new();
+    private readonly IdempotentConfiguration configuration;
+    private readonly string defaultQueue;
+
+    public DuplicateJobDetector(IMonitoringApi monitoringApi, IdempotentConfiguration configuration, string defaultQueue = "default")
+    {
+        this.monitoringApi = monitoringApi ?? throw new ArgumentNullException(nameof(monitoringApi));
+        this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        this.defaultQueue = defaultQueue ?? "default";
+    }
+
+    public bool IsDuplicateJob(Job targetJob)
+    {
+        List<KeyValuePair<string, EnqueuedJobDto?>> enqueued;
+        List<KeyValuePair<string, ScheduledJobDto?>> scheduled;
+        List<KeyValuePair<string, FetchedJobDto?>> fetched;
+
+        // Todo: See if we can can insert ourselves into the state change pipeline so we can lock around state changes and avoid race conditions.
+        lock (lockObject)
+        {
+            enqueued = monitoringApi.EnqueuedJobs(defaultQueue, 0, configuration.MaxRetrievals).ToList();
+            scheduled = monitoringApi.ScheduledJobs(0, configuration.MaxRetrievals).ToList();
+            fetched = monitoringApi.FetchedJobs(defaultQueue, 0, configuration.MaxRetrievals).ToList();
+        }
+
+        foreach (var pair in enqueued)
+        {
+            if (pair.Value?.Job != null && AreJobsEqual(pair.Value.Job, targetJob))
+                return true;
+        }
+
+        foreach (var pair in scheduled)
+        {
+            if (pair.Value?.Job != null && AreJobsEqual(pair.Value.Job, targetJob))
+                return true;
+        }
+
+        foreach (var pair in fetched)
+        {
+            if (pair.Value?.Job != null && AreJobsEqual(pair.Value.Job, targetJob))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool AreJobsEqual(Job a, Job b)
+    {
+        if (a.Type != b.Type || a.Method.Name != b.Method.Name) return false;
+        if (a.Args.Count != b.Args.Count) return false;
+
+        for (int i = 0; i < a.Args.Count; i++)
+        {
+            if (!Equals(a.Args[i], b.Args[i])) return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Hangfire.Idempotent/IdempotentJobAttribute.cs
+++ b/src/Hangfire.Idempotent/IdempotentJobAttribute.cs
@@ -1,77 +1,30 @@
 ﻿using Hangfire.Client;
 using Hangfire.Common;
-using Hangfire.Storage.Monitoring;
 
 namespace Hangfire.Idempotent;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 public class IdempotentJobAttribute : JobFilterAttribute, IClientFilter
 {
-
     internal static IdempotentConfiguration DefaultConfiguration { get; set; } = new IdempotentConfiguration();
+    private readonly DuplicateJobDetector detector;
+
+    public IdempotentJobAttribute()
+    {
+        var monitoringApi = JobStorage.Current.GetMonitoringApi();
+        detector = new DuplicateJobDetector(monitoringApi, DefaultConfiguration);
+    }
+    
     public void OnCreated(CreatedContext context) { }
 
     public void OnCreating(CreatingContext context)
     {
         if (ShouldDeduplicate(context.Job))
-            if (IsDuplicateJob(context.Job))
+        {
+            if (detector.IsDuplicateJob(context.Job))
                 context.Canceled = true;
-
+        }
     }
-
-    private bool IsDuplicateJob(Job targetJob)
-    {
-        var monitor = JobStorage.Current.GetMonitoringApi();
-
-        var state = new { Queue = "default" };
-
-        List<KeyValuePair<string, EnqueuedJobDto>> enqueued;
-        List<KeyValuePair<string, ScheduledJobDto>> scheduled;
-        List<KeyValuePair<string, FetchedJobDto>> fetched;
-
-        //Todo: See if we can can insert ourselves into the state change pipeline so we can lock around state changes and avoid race conditions.
-        lock (lockObject)
-        {
-            enqueued = monitor.EnqueuedJobs(state.Queue ?? "default", 0, DefaultConfiguration.MaxRetrievals).ToList();
-            scheduled = monitor.ScheduledJobs(0, DefaultConfiguration.MaxRetrievals).ToList();
-            fetched = monitor.FetchedJobs(state.Queue ?? "default", 0, DefaultConfiguration.MaxRetrievals).ToList();
-        }
-
-        foreach (var pair in enqueued)
-        {
-            var existing = pair.Value.Job;
-            if (AreJobsEqual(existing, targetJob)) return true;
-        }
-
-        foreach (var pair in scheduled)
-        {
-            var existing = pair.Value.Job;
-            if (AreJobsEqual(existing, targetJob)) return true;
-        }
-
-        foreach (var pair in fetched)
-        {
-            var existing = pair.Value.Job;
-            if (AreJobsEqual(existing, targetJob)) return true;
-        }
-
-        return false;
-    }
-
-    private bool AreJobsEqual(Job a, Job b)
-    {
-        if (a.Type != b.Type || a.Method.Name != b.Method.Name) return false;
-        if (a.Args.Count != b.Args.Count) return false;
-
-        for (int i = 0; i < a.Args.Count; i++)
-        {
-            if (!Equals(a.Args[i], b.Args[i])) return false;
-        }
-
-        return true;
-    }
-
-    private object lockObject = new object();   
 
     private bool ShouldDeduplicate(Job job)
     {


### PR DESCRIPTION
Hey there

Happened to come across your project, and it looks great for what I need. Thanks for putting it out there!

I tried it out, and I ran into a few minor issues:

1) it wasn't happy when the monitoring api returned null entries. This can happen with expired jobs.
2) it was only checking the `default` queue.

I've added fixes for both of these.

To test them, I've extracted the duplicate checker to it's own class, so we can pass in a mocked `IMonitoringApi`. I've added Moq as a mocking library so we can test it nicely.